### PR TITLE
Add support for minItems constraint in example-compiler

### DIFF
--- a/.changeset/three-apples-end.md
+++ b/.changeset/three-apples-end.md
@@ -1,0 +1,5 @@
+---
+'schema-openapi': patch
+---
+
+Add support for minItems constraint in example-compiler

--- a/test/example-compiler.test.ts
+++ b/test/example-compiler.test.ts
@@ -209,4 +209,12 @@ describe('constraints', () => {
 
     expect(example).toEqual([5, 2, 12, 2, 5]);
   });
+
+  test('array min length', () => {
+    const schema = Schema.array(Schema.number).pipe(Schema.minItems(3));
+
+    const example = Effect.runSync(randomExample(schema));
+
+    expect(example.length).toBeGreaterThanOrEqual(3);
+  });
 });


### PR DESCRIPTION
Also fixes an issue where a number constraint is applied on the array. The constraint for the should be on the type inside the array, not on the array schema.