### PR TITLE
Add possibility to define security schemas and requirements

### DIFF
--- a/.changeset/violet-moose-end.md
+++ b/.changeset/violet-moose-end.md
@@ -1,0 +1,5 @@
+---
+'schema-openapi': patch
+---
+
+Add possibility to define security schemas and requirements

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -4,6 +4,8 @@ import * as I from 'schema-openapi/internal';
 import type {
   AnySchema,
   OpenAPISchemaType,
+  OpenAPISecurityRequirement,
+  OpenAPISecurityScheme,
   OpenAPISpec,
   OpenAPISpecInfo,
   OpenAPISpecMethodName,
@@ -436,6 +438,48 @@ export const responseHeaders =
         },
       };
     }, {}),
+  });
+
+/**
+ * Add a security scheme to the specification.
+ *
+ * *Setter of*: `openAPI`
+ *
+ * @param {string} name - name of the security scheme
+ * @param {OpenAPISecurityScheme} securityScheme - security scheme
+ */
+export const securityScheme =
+  (
+    name: string,
+    securityScheme: OpenAPISecurityScheme
+  ): I.Setter<OpenAPISpec<OpenAPISchemaType>> =>
+  (spec) => ({
+    ...spec,
+    components: {
+      ...spec.components,
+      securitySchemes: {
+        ...spec.components?.securitySchemes,
+        [name]: securityScheme,
+      },
+    },
+  });
+
+/**
+ * Add a security requirement to the specification.
+ *
+ * *Setter of*: `openAPI`, `operation`
+ *
+ * @param {string} securityScheme - name of the security scheme
+ * @param {string[]} scopes - list of required OAuth2 scopes
+ */
+export const securityRequirement =
+  (
+    securityScheme: string,
+    scopes: string[] = []
+  ): I.Setter<{ security?: OpenAPISecurityRequirement[] }> =>
+  (spec) => ({
+    ...spec,
+    security: [...(spec.security ?? []), { [securityScheme]: scopes }],
   });
 
 // internals

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type OpenAPISpec<S = AnySchema> = {
   servers?: OpenAPISpecServer[];
   paths: OpenAPISpecPaths<S>;
   components?: OpenAPIComponents<S>;
+  security?: OpenAPISecurityRequirement[];
 };
 
 export type OpenAPISpecInfo = {
@@ -112,8 +113,48 @@ export type OpenAPISpecReference = {
 };
 
 export type OpenAPIComponents<S = AnySchema> = {
-  schemas: Record<string, S>;
+  schemas?: Record<string, S>;
+  securitySchemes?: Record<string, OpenAPISecurityScheme>;
 };
+
+export type OpenAPIHTTPSecurityScheme = {
+  type: 'http';
+  scheme: string;
+  bearerFormat?: string;
+};
+
+export type OpenAPIApiKeySecurityScheme = {
+  type: 'apiKey';
+  name: string;
+  in: 'query' | 'header' | 'cookie';
+};
+
+export type OpenAPIMutualTLSSecurityScheme = {
+  type: 'mutualTLS';
+};
+
+export type OpenAPIOAuth2SecurityScheme = {
+  type: 'oauth2';
+  flows: Record<
+    'implicit' | 'password' | 'clientCredentials' | 'authorizationCode',
+    Record<string, unknown>
+  >;
+};
+
+export type OpenAPIOpenIdConnectSecurityScheme = {
+  type: 'openIdConnect';
+  openIdConnectUrl: string;
+};
+
+export type OpenAPISecurityScheme =
+  | OpenAPIHTTPSecurityScheme
+  | OpenAPIApiKeySecurityScheme
+  | OpenAPIMutualTLSSecurityScheme
+  | OpenAPIOAuth2SecurityScheme
+  | OpenAPIOpenIdConnectSecurityScheme
+  | OpenAPISpecReference;
+
+export type OpenAPISecurityRequirement = Record<string, string[]>;
 
 export type OpenAPISpecOperation<S = AnySchema> = {
   requestBody?: OpenAPISpecRequestBody<S>;
@@ -124,6 +165,7 @@ export type OpenAPISpecOperation<S = AnySchema> = {
   summary?: string;
   deprecated?: boolean;
   tags?: string[];
+  security?: OpenAPISecurityRequirement[];
 };
 
 // Open API schema

--- a/test/openapi.test.ts
+++ b/test/openapi.test.ts
@@ -529,3 +529,38 @@ describe('simple', () => {
     SwaggerParser.validate(spec);
   });
 });
+
+it('security', async () => {
+  const schema = Schema.string;
+
+  const spec = OpenApi.openAPI(
+    'test',
+    '0.1',
+    OpenApi.securityScheme('bearerAuth', {
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'JWT',
+    }),
+    OpenApi.path(
+      '/pet',
+      OpenApi.operation(
+        'post',
+        OpenApi.jsonRequest(schema),
+        OpenApi.jsonResponse(200, schema, 'test'),
+        OpenApi.securityRequirement('bearerAuth')
+      )
+    )
+  );
+
+  expect(spec.components?.securitySchemes).toEqual({
+    bearerAuth: {
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'JWT',
+    },
+  });
+  expect(spec.paths['/pet'].post?.security).toEqual([{ bearerAuth: [] }]);
+
+  // @ts-expect-error
+  SwaggerParser.validate(spec);
+});


### PR DESCRIPTION
I'm not really sure how to handle the construction of the polymorphic `OpenAPISecurityScheme` well. Currently you just give the whole object as a parameter.