### PR TITLE
add description for security types

### DIFF
--- a/.changeset/real-kids-confess.md
+++ b/.changeset/real-kids-confess.md
@@ -1,0 +1,5 @@
+---
+"schema-openapi": minor
+---
+
+add description for security types

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,22 +132,26 @@ export type OpenAPIComponents<S = AnySchema> = {
 
 export type OpenAPIHTTPSecurityScheme = {
   type: 'http';
+  description?: string;
   scheme: string;
   bearerFormat?: string;
 };
 
 export type OpenAPIApiKeySecurityScheme = {
   type: 'apiKey';
+  description?: string;
   name: string;
   in: 'query' | 'header' | 'cookie';
 };
 
 export type OpenAPIMutualTLSSecurityScheme = {
   type: 'mutualTLS';
+  description?: string;
 };
 
 export type OpenAPIOAuth2SecurityScheme = {
   type: 'oauth2';
+  description?: string;
   flows: Record<
     'implicit' | 'password' | 'clientCredentials' | 'authorizationCode',
     Record<string, unknown>
@@ -156,6 +160,7 @@ export type OpenAPIOAuth2SecurityScheme = {
 
 export type OpenAPIOpenIdConnectSecurityScheme = {
   type: 'openIdConnect';
+  description?: string;
   openIdConnectUrl: string;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,7 +133,8 @@ export type OpenAPIComponents<S = AnySchema> = {
 export type OpenAPIHTTPSecurityScheme = {
   type: 'http';
   description?: string;
-  scheme: string;
+  scheme: 'bearer' | 'basic' | string;
+  /* only for scheme: 'bearer' */
   bearerFormat?: string;
 };
 


### PR DESCRIPTION
Add `description?: string;`
https://swagger.io/specification/#security-scheme-object

<img width="1105" alt="image" src="https://github.com/sukovanej/schema-openapi/assets/16162053/2c04e49d-a8be-401d-9a12-168d4d680d53">
