### PR TITLE
Add type to enum literal singleton

### DIFF
--- a/.changeset/modern-bats-kiss.md
+++ b/.changeset/modern-bats-kiss.md
@@ -1,0 +1,5 @@
+---
+"schema-openapi": patch
+---
+
+Add type for enum singleton in generated OpenAPI

--- a/src/OpenApiTypes.ts
+++ b/src/OpenApiTypes.ts
@@ -380,7 +380,8 @@ export type OpenAPISchemaArrayType = {
  * @since 1.0.0
  */
 export type OpenAPISchemaEnumType = {
-  enum: Array<string | number | boolean>
+  type: "string" | "number" | "boolean"
+  enum: Array<string | number | boolean | null>
   nullable?: boolean
 }
 

--- a/test/dataTypes.test.ts
+++ b/test/dataTypes.test.ts
@@ -500,7 +500,7 @@ describe("description annotation", () => {
       type: "object",
       properties: {
         id: { type: "integer", description: "id description" },
-        name: { enum: ["value"], description: "value description" }
+        name: { type: "string", enum: ["value"], description: "value description" }
       },
       required: ["name", "id"],
       description: "my description"

--- a/test/openapi.test.ts
+++ b/test/openapi.test.ts
@@ -630,7 +630,7 @@ describe("simple", () => {
             responses: {
               200: {
                 content: {
-                  "application/json": { schema: { enum: ["value"] } }
+                  "application/json": { schema: { enum: ["value"], type: "string" } }
                 },
                 description: "test"
               }


### PR DESCRIPTION
When I do
```ts
S.Literal('one')
```
I don't get any associated type in the generated OpenAPI.

This works when using more than one literal though: `S.Literal('one', 'two')` will correctly generate the associated type.

As far as I know, an enum should always have an associated type. 

Plus it renders bad in Swagger UI without a type.